### PR TITLE
Build docker image phrase-cli:alpine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
         name: Release
         run: |
           make all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:latest AS phrase-cli
+
+# do stuff
+COPY dist/phrase_linux_amd64 /usr/bin/phrase
+
+ENTRYPOINT ["/usr/bin/phrase"]

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -eo pipefail
 
 echo "Build release $VERSION"
@@ -12,8 +11,15 @@ sed -e "s/VERSION/${VERSION}/g" ./build/innosetup/phrase-cli.iss.template > ./bu
 ./build/innosetup/create_installer.sh
 
 # build docker image
-docker build --tag phrase-cli:latest --tag phrase-cli:${VERSION} -f ./Dockerfile
-# push to dockerhub
+
+IMAGE_PREFIX=phrase/phrase-cli
+IMAGE=${IMAGE_PREFIX}:${VERSION}
+
+echo build docker image ${IMAGE}
+docker build --tag ${IMAGE} -f ./Dockerfile .
+
+echo push image ${IMAGE}
+docker push ${IMAGE}
 
 # Create release
 function create_release_data()
@@ -35,20 +41,20 @@ release_id=$(echo $response | python -c "import sys, json; print json.load(sys.s
 
 if [ -z "$release_id" ]
 then
-      echo "Failed to create GitHub release"
-      echo $response
-      exit 1
+  echo "Failed to create GitHub release"
+  echo $response
+  exit 1
 else
-      echo "New release created created with id: ${release_id}"
+  echo "New release created created with id: ${release_id}"
 fi
 
 # Upload artifacts
 DIST_DIR="./dist"
 for file in "$DIST_DIR"/*; do
-    echo "Uploading ${file}"
-    asset="https://uploads.github.com/repos/phrase/phrase-cli/releases/${release_id}/assets?name=$(basename "$file")&access_token=${GITHUB_TOKEN}"
-    curl -sS --data-binary @"$file" -H "Content-Type: application/octet-stream" $asset > /dev/null
-    echo Hash: $(sha256sum $file)
+  echo "Uploading ${file}"
+  asset="https://uploads.github.com/repos/phrase/phrase-cli/releases/${release_id}/assets?name=$(basename "$file")&access_token=${GITHUB_TOKEN}"
+  curl -sS --data-binary @"$file" -H "Content-Type: application/octet-stream" $asset > /dev/null
+  echo Hash: $(sha256sum $file)
 done
 
 echo "Release successful"

--- a/build/release.sh
+++ b/build/release.sh
@@ -11,6 +11,10 @@ sed -e "s/VERSION/${VERSION}/g" ./build/innosetup/phrase-cli.iss.template > ./bu
 ./build/build.sh
 ./build/innosetup/create_installer.sh
 
+# build docker image
+docker build --tag phrase-cli:latest --tag phrase-cli:${VERSION} -f ./Dockerfile
+# push to dockerhub
+
 # Create release
 function create_release_data()
 {


### PR DESCRIPTION
The purpose of this PR is to package the `phrase-cli` binary in a docker image and push it to Dockerhub.

This is achieved with GitHb actions with a combination of a tagged commit.

To tag a commit, use a command similar to:
```bash
TAG=2.0.15-alpha8; git tag -s -a ${TAG} -m ${TAG} && git push origin docker --tags
```

For Dockerhub, I suggest we also use a suffix to inform about the linux version used. For us it would mean a `-alpine` suffix.