### PR TITLE
Create tar.gz archive for Linux arm64 as well

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -23,7 +23,7 @@ for name in phrase_macosx_amd64 phrase_macosx_arm64; do
   rm phrase
 done
 
-for name in phrase_linux_386 phrase_linux_amd64; do
+for name in phrase_linux_386 phrase_linux_amd64 phrase_linux_arm64; do
   tar --create --mtime="@${SOURCE_DATE_EPOCH}" $name | gzip -n > ${name}.tar.gz
 done
 


### PR DESCRIPTION
Currently the Linux arm64 release is only available as a binary and not as an archive, this will save some transfer bytes.