### PR TITLE
fix: bump phrase/phrase-go/v2 to 2.11.0 to fix build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0
-	github.com/phrase/phrase-go/v2 v2.10.3
+	github.com/phrase/phrase-go/v2 v2.11.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
-github.com/phrase/phrase-go/v2 v2.10.3 h1:MZvJuVXw/ImtyWSsaWcP32R1zlL+7sN17e9UR1qlvPY=
-github.com/phrase/phrase-go/v2 v2.10.3/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
+github.com/phrase/phrase-go/v2 v2.11.0 h1:MQWSxH/UZgpOhH1hXg3smpQse61SSzkQNLixF9CQMrw=
+github.com/phrase/phrase-go/v2 v2.11.0/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=


### PR DESCRIPTION
Bump phrase-go to fix the following build error:

```
cmd/api_comment_reactions.go:49:29: undefined: api.ReactionCreateOpts
cmd/api_comment_reactions.go:66:38: client.CommentReactionsApi undefined (type *phrase.APIClient has no field or method CommentReactionsApi)
cmd/api_comment_reactions.go:120:29: undefined: api.ReactionDeleteOpts
cmd/api_comment_reactions.go:138:38: client.CommentReactionsApi undefined (type *phrase.APIClient has no field or method CommentReactionsApi)
cmd/api_comment_reactions.go:188:29: undefined: api.ReactionShowOpts
cmd/api_comment_reactions.go:206:38: client.CommentReactionsApi undefined (type *phrase.APIClient has no field or method CommentReactionsApi)
cmd/api_comment_reactions.go:261:29: undefined: api.ReactionsListOpts
cmd/api_comment_reactions.go:286:38: client.CommentReactionsApi undefined (type *phrase.APIClient has no field or method CommentReactionsApi)
```

relates to https://github.com/Homebrew/homebrew-core/pull/140271