### PR TITLE
ci(release.sh): add link to changelog to release body

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -34,7 +34,7 @@ function create_release_data()
   "name": "${VERSION}",
   "draft": true,
   "prerelease": false,
-  "body": "https://github.com/phrase/openapi/blob/master/clients/cli/CHANGELOG.md"
+  "body": "https://github.com/phrase/phrase-cli/blob/master/CHANGELOG.md"
 }
 EOF
 }

--- a/build/release.sh
+++ b/build/release.sh
@@ -33,7 +33,8 @@ function create_release_data()
   "tag_name": "${VERSION}",
   "name": "${VERSION}",
   "draft": true,
-  "prerelease": false
+  "prerelease": false,
+  "body": "https://github.com/phrase/openapi/blob/master/clients/cli/CHANGELOG.md"
 }
 EOF
 }


### PR DESCRIPTION
Adds a link to https://github.com/phrase/openapi/blob/master/clients/cli/CHANGELOG.md to the body of the release, so that the changelog can easily be found by users that are subscribed to new releases.