### PR TITLE
STRINGS-374 Enable users to provide a prefix during CLI push

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,5 +38,6 @@ func initPush() {
 	AddFlag(pushCmd, "string", "branch", "b", "branch", false)
 	AddFlag(pushCmd, "bool", "use-local-branch-name", "", "push from the branch with the name of your currently checked out branch (git or mercurial)", false)
 	AddFlag(pushCmd, "string", "tag", "", "Tag uploaded keys", false)
+	AddFlag(pushCmd, "string", "translation-key-prefix", "", "Prefix for the names of the translation keys", false)
 	params.BindPFlags(pushCmd.Flags())
 }


### PR DESCRIPTION
Purpose: Add a new flag to allow users to use a prefix for the pushed translation key names.

Related tickets:
https://phrase.atlassian.net/browse/STRINGS-374