### PR TITLE
STRINGS-564 - Error-code when pulling a non-existing branch

### DIFF
--- a/cmd/internal/pull.go
+++ b/cmd/internal/pull.go
@@ -71,7 +71,7 @@ func (cmd *PullCommand) Run(config *phrase.Config) error {
 		val, ok := localesCache[LocalesCacheKey{target.ProjectID, target.GetBranch()}]
 		if !ok || len(val) == 0 {
 			if cmd.Branch != "" {
-				continue
+				return fmt.Errorf("Branch '%s' does not exist in project '%s'", cmd.Branch, target.ProjectID)
 			}
 			return fmt.Errorf("Could not find any locales for project %q", target.ProjectID)
 		}


### PR DESCRIPTION
- When using `pull` command with branch param and the requested branch does not exist, answer with exit-code `1` instead of `0`. 
- Also adds an error message

### See Screenshot
![image](https://github.com/user-attachments/assets/797dbd26-a989-4db1-86a5-b41d12e1e8d5)
